### PR TITLE
WIP: add select_nic method to gridscale fog-extension concern.

### DIFF
--- a/app/models/concerns/fog_extensions/gridscale/server.rb
+++ b/app/models/concerns/fog_extensions/gridscale/server.rb
@@ -58,10 +58,6 @@ module FogExtensions
       end
 
       def select_nic(fog_nics, nic)
-        # NB: fog_nics seems to be always nil here so this raises an exception.
-        # 
-        # if we would have a list of interfaces in fog_nics, we would need to
-        # return the one from fog_nics we want to match to the foreman nic.
         # foreman-xenserver uses fog_nics[0] here, so I'll just copy that for now.
         fog_nics[0]
       end

--- a/app/models/concerns/fog_extensions/gridscale/server.rb
+++ b/app/models/concerns/fog_extensions/gridscale/server.rb
@@ -57,7 +57,14 @@ module FogExtensions
         :mac
       end
 
-
+      def select_nic(fog_nics, nic)
+        # NB: fog_nics seems to be always nil here so this raises an exception.
+        # 
+        # if we would have a list of interfaces in fog_nics, we would need to
+        # return the one from fog_nics we want to match to the foreman nic.
+        # foreman-xenserver uses fog_nics[0] here, so I'll just copy that for now.
+        fog_nics[0]
+      end
     end
   end
 end


### PR DESCRIPTION
this currently creates another error 

    NoMethodError: undefined method `[]' for nil:NilClass

with my test setup, as fog-gridscale doesn't set the "interfaces" attribute, which is used by foreman here:
https://github.com/theforeman/foreman/blob/c23a83afe9fcd6d2f25d261eb0c303a7cf337ffa/app/models/concerns/orchestration/compute.rb#L339

just returning `nil` in select_nic also doesn't work, as foreman aborts the machine creation with

    Could not find virtual machine network interface matching $hostname

this could be related to my test-setup, though.